### PR TITLE
Change some default languages from "C++" to macro "DEFAULT_LANGUAGE" which is "C++14" now

### DIFF
--- a/uoj_judger/Makefile
+++ b/uoj_judger/Makefile
@@ -1,5 +1,5 @@
 INCLUDE_PATH = include
-CXXFLAGS = -I./include -O2 -std=c++11
+CXXFLAGS = -I./include -O2 -std=c++14
 
 EXE_CHECKER = \
 	builtin/checker/acmp2 \

--- a/uoj_judger/include/uoj_env.h
+++ b/uoj_judger/include/uoj_env.h
@@ -36,3 +36,5 @@
 #define RS_HK_SPJ_DGS (successed_hack + RS_SPJ_DGS)
 #define RS_HK_SPJ_JGF (successed_hack + RS_SPJ_JGF)
 
+#define DEFAULT_CPP_LANGUAGE "C++14"
+#define DEFAULT_LANGUAGE DEFAULT_CPP_LANGUAGE

--- a/uoj_judger/include/uoj_judger.h
+++ b/uoj_judger/include/uoj_judger.h
@@ -934,7 +934,7 @@ void prepare_interactor() {
 	string data_path_std = data_path + "/interactor";
 	string work_path_std = work_path + "/interactor";
 	executef("cp %s %s", data_path_std.c_str(), work_path_std.c_str());
-	conf_add("interactor_language", "C++");
+	conf_add("interactor_language", DEFAULT_LANGUAGE);
 	prepared = true;
 }
 
@@ -1011,7 +1011,7 @@ void prepare_run_standard_program() {
 	string data_path_std = data_path + "/std";
 	string work_path_std = work_path + "/std";
 	executef("cp %s %s", data_path_std.c_str(), work_path_std.c_str());
-	conf_add("std_language", "C++");
+	conf_add("std_language", DEFAULT_LANGUAGE);
 	prepared = true;
 }
 
@@ -1289,6 +1289,8 @@ RunCompilerResult compile(const char *name)  {
 
 	RunCompilerResult res = RunCompilerResult::failed_result();
 	res.info = "This language is not supported yet.";
+	if (lang == "C++")
+		res.info += " (Note: Please use \"C++98\" or \"C++14\" or the other specific standard instead of \"C++\".)";
 	return res;
 }
 
@@ -1332,6 +1334,8 @@ RunCompilerResult compile_with_implementer(const char *name)  {
 
 	RunCompilerResult res = RunCompilerResult::failed_result();
 	res.info = "This language is not supported yet.";
+	if (lang == "C++")
+		res.info += " (Note: Please use \"C++98\" or \"C++14\" or the other specific standard instead of \"C++\".)";
 	return res;
 }
 

--- a/uoj_judger/include/uoj_judger.h
+++ b/uoj_judger/include/uoj_judger.h
@@ -1290,7 +1290,7 @@ RunCompilerResult compile(const char *name)  {
 	RunCompilerResult res = RunCompilerResult::failed_result();
 	res.info = "This language is not supported yet.";
 	if (lang == "C++")
-		res.info += " (Note: Please use \"C++98\" or \"C++14\" or the other specific standard instead of \"C++\".)";
+		res.info += " (Note: Please use \"C++98\" or \"C++14\" or another specific standard instead of \"C++\".)";
 	return res;
 }
 
@@ -1335,7 +1335,7 @@ RunCompilerResult compile_with_implementer(const char *name)  {
 	RunCompilerResult res = RunCompilerResult::failed_result();
 	res.info = "This language is not supported yet.";
 	if (lang == "C++")
-		res.info += " (Note: Please use \"C++98\" or \"C++14\" or the other specific standard instead of \"C++\".)";
+		res.info += " (Note: Please use \"C++98\" or \"C++14\" or another specific standard instead of \"C++\".)";
 	return res;
 }
 


### PR DESCRIPTION
Add macros `DEFAULT_CPP_LANGUAGE` `DEFAULT_LANGUAGE` which are `"C++14"` now.
Update `uoj_judger.h` to change some default languages from `"C++"` to macro `DEFAULT_LANGUAGE` which is `"C++14"` now.
Add some tips for compiling language `"C++"`.
添加了宏 `DEFAULT_CPP_LANGUAGE` `DEFAULT_LANGUAGE`，当前值均为 `"C++14"`。
将 `uoj_judger.h` 中的一些默认语言从 `"C++"` 改为了 `DEFAULT_LANGUAGE`。
为编译语言 `"C++"` 添加了修正提示。